### PR TITLE
Fix translation

### DIFF
--- a/Assets/JS/QuickCreate.js
+++ b/Assets/JS/QuickCreate.js
@@ -650,7 +650,7 @@
 
             let html = '';
             html += '<div class="card mb-2">';
-            html += `<div class="card-header py-2"><small class="text-muted"><i class="fas fa-calculator me-1"></i>${this.trans('accounting')}</small></div>`;
+            html += `<div class="card-header py-2"><small class="text-muted"><i class="fas fa-calculator me-1"></i>${this.trans('accounting-section')}</small></div>`;
             html += '<div class="card-body py-2">';
             html += '<div class="row">';
             html += this.buildSubcuentaInputHtml('quickCreateProductPurchaseAccount', 'codsubcuentacom', this.trans('purchase-account'), 'col-md-6');
@@ -1796,7 +1796,7 @@
                 'warehouse': 'Almacén',
                 'purchase-data': 'Datos de compra (opcional)',
                 'stock-data': 'Stock inicial (opcional)',
-                'accounting': 'Contabilidad (opcional)',
+                'accounting-section': 'Contabilidad (opcional)',
                 'sale-price': 'Precio venta',
                 'no-stock-control': 'No controlar stock',
                 'allow-sale-without-stock': 'Permitir venta sin stock',

--- a/Translation/en_EN.json
+++ b/Translation/en_EN.json
@@ -1,6 +1,6 @@
 {
     "account-already-exists": "Account already exists",
-    "accounting": "Accounting (optional)",
+    "accounting-section": "Accounting (optional)",
     "all-accounts": "All accounts",
     "create-subaccount-code": "Create subaccount",
     "filter-by-account": "Filter by account",

--- a/Translation/es_ES.json
+++ b/Translation/es_ES.json
@@ -1,6 +1,6 @@
 {
     "account-already-exists": "La subcuenta ya existe",
-    "accounting": "Contabilidad (opcional)",
+    "accounting-section": "Contabilidad (opcional)",
     "all-accounts": "Todas las cuentas",
     "create-subaccount-code": "Crear subcuenta",
     "filter-by-account": "Filtrar por cuenta",


### PR DESCRIPTION
This pull request updates the label for the accounting section in the quick create product UI to use a more specific translation key, ensuring consistency across the codebase and translation files. The main change is renaming the translation key from `accounting` to `accounting-section` in both the JavaScript and translation JSON files.

**Internationalization and UI consistency:**

* Updated the translation key from `accounting` to `accounting-section` in the English and Spanish translation files (`Translation/en_EN.json`, `Translation/es_ES.json`) to provide a more descriptive label for the accounting section. [[1]](diffhunk://#diff-42e72afed16973920c25c636e7c44a9547ac35aaf8639f70534e5e8eb2563520L3-R3) [[2]](diffhunk://#diff-8daa13d9a805104f47230b3c54679c84fb321b063c7916499453aaef8bf52613L3-R3)
* Refactored the usage of the translation key in `Assets/JS/QuickCreate.js` to match the new key, both in the translation mapping and in the HTML generation for the accounting section header. [[1]](diffhunk://#diff-9cfdc6d56708e8f40312a2e3256c5ba8b08d8be29b54fe437a8504e68bbffc87L1799-R1799) [[2]](diffhunk://#diff-9cfdc6d56708e8f40312a2e3256c5ba8b08d8be29b54fe437a8504e68bbffc87L653-R653)