### PR TITLE
Support php 8.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
 
     strategy:
       matrix:
-        php-version: ['8.2', '8.3', '8.4']
+        php-version: ['8.1', '8.2', '8.3', '8.4']
 
     services:
       mysql:

--- a/facturascripts.ini
+++ b/facturascripts.ini
@@ -2,4 +2,4 @@ name = 'QuickCreate'
 description = 'Crea productos y subcuentas rápidamente desde los desplegables de documentos'
 version = 1
 min_version = 2025
-min_php = 8.2
+min_php = 8.1


### PR DESCRIPTION
This pull request updates the minimum required PHP version for the `QuickCreate` plugin and expands the PHP version matrix in the CI workflow to include PHP 8.1. These changes ensure broader compatibility and more comprehensive testing coverage.

Compatibility updates:

* Lowered the minimum PHP version requirement for the `QuickCreate` plugin from 8.2 to 8.1 in `facturascripts.ini`.

Continuous integration improvements:

* Added PHP 8.1 to the CI workflow matrix in `.github/workflows/ci.yml`, allowing automated tests to run on PHP versions 8.1 through 8.4.