### PR TITLE
Añadir codigo de barras al modal

### DIFF
--- a/Assets/JS/QuickCreate.js
+++ b/Assets/JS/QuickCreate.js
@@ -1222,6 +1222,12 @@
                                             <!-- Family select will be injected here -->
                                         </div>
                                     </div>
+                                    <div class="row mb-3">
+                                        <div class="col-md-3">
+                                            <label for="quickCreateProductBarcode" class="form-label">${this.trans('barcode')}</label>
+                                            <input type="text" class="form-control" id="quickCreateProductBarcode" name="codbarras">
+                                        </div>
+                                    </div>
                                     <div id="quickCreateProductDynamicFields"></div>
                                     <div id="quickCreateProductPurchaseFields"></div>
                                     <div id="quickCreateProductStockFields"></div>
@@ -1803,6 +1809,7 @@
             // Fallback translations
             const fallback = {
                 'quick-create-product': 'Crear producto',
+                'barcode': 'Código de barras',
                 'quick-create-account': 'Crear subcuenta',
                 'create-subcuenta': 'Crear subcuenta',
                 'create-subaccount-code': 'Crear subcuenta',

--- a/Controller/QuickCreateAction.php
+++ b/Controller/QuickCreateAction.php
@@ -126,6 +126,7 @@ class QuickCreateAction extends Controller
         $nostock = $this->request->get('nostock', '') === 'TRUE';
         $ventasinstock = $this->request->get('ventasinstock', '') === 'TRUE';
         $publico = $this->request->get('publico', '') === 'TRUE';
+        $codbarras = $this->request->get('codbarras', '');
 
         // Validate required fields
         if (empty($referencia)) {
@@ -191,9 +192,9 @@ class QuickCreateAction extends Controller
             return;
         }
 
-        // Get the auto-created variante
         $variante = new Variante();
         $variante->loadFromCode('', [new DataBaseWhere('idproducto', $producto->idproducto)]);
+        $variante->codbarras = $codbarras;
 
         // Update variante with precio, coste and margen
         $codproveedor = $this->request->get('codproveedor', '');

--- a/Translation/en_EN.json
+++ b/Translation/en_EN.json
@@ -1,5 +1,6 @@
 {
     "account-already-exists": "Account already exists",
+    "barcode": "Barcode",
     "accounting-section": "Accounting (optional)",
     "all-accounts": "All accounts",
     "create-subaccount-code": "Create subaccount",

--- a/Translation/es_ES.json
+++ b/Translation/es_ES.json
@@ -1,5 +1,6 @@
 {
     "account-already-exists": "La subcuenta ya existe",
+    "barcode": "Código de barras",
     "accounting-section": "Contabilidad (opcional)",
     "all-accounts": "Todas las cuentas",
     "create-subaccount-code": "Crear subcuenta",


### PR DESCRIPTION
Evita la necesidad de tener que volver al producto y después entrar en la variante para guardar el código de barras, agregando muy poca complejidad, conseguimos mayor agilidad en la creación del producto. 