### PR TITLE
ci: add PHP 8.5 to the test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
 
     strategy:
       matrix:
-        php-version: ['8.1', '8.2', '8.3', '8.4']
+        php-version: ['8.1', '8.2', '8.3', '8.4', '8.5']
 
     services:
       mysql:


### PR DESCRIPTION
## What

Add **PHP 8.5** to the CI test matrix, alongside 8.1–8.4.

## Why

Verifies the plugin against the latest PHP release. The same change was
validated in `facturascripts-plugin-AiScan` (the `test (8.5)` leg passes:
upstream FacturaScripts installs and the suite runs cleanly on 8.5). Applying
it here keeps the plugin pipelines consistent and catches 8.5 regressions
early.